### PR TITLE
feat!: trigger v4 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "event",
     "dark-mode",
     "internationalization",
+    "schedule-x",
     "preact"
   ],
   "exports": {


### PR DESCRIPTION
Adds a tiny package metadata change so a fresh commit can carry the missing semantic-release breaking-change marker. When this lands on `main`, semantic-release should classify the change as a major release and publish the v4 line.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
